### PR TITLE
Move the SearchIntegrator selection inside the DatasourceMapper

### DIFF
--- a/config/src/main/java/me/snowdrop/data/hibernatesearch/config/HibernateSearchDataAutoConfiguration.java
+++ b/config/src/main/java/me/snowdrop/data/hibernatesearch/config/HibernateSearchDataAutoConfiguration.java
@@ -45,17 +45,6 @@ import org.springframework.orm.jpa.SharedEntityManagerCreator;
 @AutoConfigureAfter({HibernateJpaAutoConfiguration.class})
 public class HibernateSearchDataAutoConfiguration {
 
-  @Bean(destroyMethod = "close", name = "searchIntegrator")
-  @ConditionalOnBean(EntityManagerFactory.class)
-  public SearchIntegrator createSearchIntegrator(EntityManagerFactory emf) {
-    final EntityManager throwAwayEM = emf.createEntityManager();
-    try {
-      return Search.getFullTextEntityManager(throwAwayEM).getSearchFactory().unwrap(SearchIntegrator.class);
-    } finally {
-      throwAwayEM.close();
-    }
-  }
-
   @Bean(name = "datasourceMapper")
   @ConditionalOnMissingBean(DatasourceMapper.class)
   @ConditionalOnBean(EntityManagerFactory.class)

--- a/config/src/main/java/me/snowdrop/data/hibernatesearch/config/JpaDatasourceMapper.java
+++ b/config/src/main/java/me/snowdrop/data/hibernatesearch/config/JpaDatasourceMapper.java
@@ -25,6 +25,9 @@ import me.snowdrop.data.hibernatesearch.spi.DatasourceMapper;
 import me.snowdrop.data.hibernatesearch.spi.QueryAdapter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.search.hcore.util.impl.ContextHelper;
 import org.hibernate.search.jpa.FullTextEntityManager;
 import org.hibernate.search.jpa.FullTextQuery;
 import org.hibernate.search.jpa.Search;
@@ -37,11 +40,20 @@ import org.springframework.util.Assert;
  */
 public class JpaDatasourceMapper implements DatasourceMapper {
 
+  private SearchIntegrator searchIntegrator;
   private EntityManagerFactory emf;
 
   public JpaDatasourceMapper(EntityManagerFactory emf) {
     Assert.notNull(emf, "Null EntityManagerFactory!");
     this.emf = emf;
+  }
+
+  @Override
+  public SearchIntegrator getSearchIntegrator() {
+    if ( searchIntegrator == null ) {
+      searchIntegrator = ContextHelper.getSearchintegratorBySFI( emf.unwrap( SessionFactoryImplementor.class ) );
+    }
+    return searchIntegrator;
   }
 
   @Override
@@ -65,7 +77,7 @@ public class JpaDatasourceMapper implements DatasourceMapper {
     }
 
     @Override
-    public void applyLuceneQuery(SearchIntegrator searchIntegrator, Query query) {
+    public void applyLuceneQuery(Query query) {
       EntityManager em = EntityManagerFactoryUtils.getTransactionalEntityManager(emf);
       if (em == null) {
         entityManager = emf.createEntityManager();

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/core/AbstractQueryAdapter.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/core/AbstractQueryAdapter.java
@@ -32,16 +32,19 @@ import org.hibernate.search.spi.SearchIntegrator;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public abstract class AbstractQueryAdapter<T> implements QueryAdapter<T> {
+  private final SearchIntegrator searchIntegrator;
   private final Class<T> entityClass;
   private HSQuery hsQuery;
 
-  public AbstractQueryAdapter(Class<T> entityClass) {
+  public AbstractQueryAdapter(SearchIntegrator searchIntegrator, Class<T> entityClass) {
+    this.searchIntegrator = searchIntegrator;
     this.entityClass = entityClass;
   }
 
   protected abstract T get(Class<T> entityClass, Serializable id);
 
-  public void applyLuceneQuery(SearchIntegrator searchIntegrator, Query query) {
+  @Override
+  public void applyLuceneQuery(Query query) {
     hsQuery = searchIntegrator
       .createHSQuery()
       .luceneQuery(query)

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/core/HibernateSearchTemplate.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/core/HibernateSearchTemplate.java
@@ -40,9 +40,9 @@ public class HibernateSearchTemplate implements HibernateSearchOperations {
   private final DatasourceMapper datasourceMapper;
   private MappingContext<?, HibernateSearchPersistentProperty> mappingContext;
 
-  public HibernateSearchTemplate(SearchIntegrator searchIntegrator, DatasourceMapper datasourceMapper) {
-    this.searchIntegrator = searchIntegrator;
+  public HibernateSearchTemplate(DatasourceMapper datasourceMapper) {
     this.datasourceMapper = datasourceMapper;
+    this.searchIntegrator = datasourceMapper.getSearchIntegrator();
   }
 
   private <T> List<T> findAllInternal(Query query) {

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/core/query/QueryConverter.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/core/query/QueryConverter.java
@@ -86,7 +86,7 @@ public class QueryConverter {
   }
 
   private void fillQuery(QueryAdapter queryAdapter, Query query, org.apache.lucene.search.Query luceneQuery) {
-    queryAdapter.applyLuceneQuery(searchIntegrator, luceneQuery);
+    queryAdapter.applyLuceneQuery(luceneQuery);
     addSortToQuery(queryAdapter, query);
     addPagingToQuery(queryAdapter, query);
   }

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/repository/config/EnableHibernateSearchRepositories.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/repository/config/EnableHibernateSearchRepositories.java
@@ -60,12 +60,6 @@ public @interface EnableHibernateSearchRepositories {
   Class<?> repositoryBaseClass() default DefaultRepositoryBaseClass.class;
 
   /**
-   * Configures the name of the {@link SearchIntegrator} bean definition to be used to create repositories
-   * discovered through this annotation. Defaults to {@code searchIntegrator}.
-   */
-  String searchIntegratorRef() default "searchIntegrator";
-
-  /**
    * Configures the name of the {@link DatasourceMapper} bean definition to be used to create repositories
    * discovered through this annotation. Defaults to {@code datasourceMapper}.
    */

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/repository/config/HibernateSearchRepositoryConfigExtension.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/repository/config/HibernateSearchRepositoryConfigExtension.java
@@ -55,7 +55,6 @@ public class HibernateSearchRepositoryConfigExtension extends RepositoryConfigur
   @Override
   public void postProcess(BeanDefinitionBuilder builder, AnnotationRepositoryConfigurationSource config) {
     AnnotationAttributes attributes = config.getAttributes();
-    builder.addPropertyReference("searchIntegrator", attributes.getString("searchIntegratorRef"));
     builder.addPropertyReference("datasourceMapper", attributes.getString("datasourceMapperRef"));
   }
 }

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/repository/support/HibernateSearchRepositoryFactoryBean.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/repository/support/HibernateSearchRepositoryFactoryBean.java
@@ -32,7 +32,6 @@ import org.springframework.util.Assert;
  */
 public class HibernateSearchRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable> extends RepositoryFactoryBeanSupport<T, S, ID> {
 
-  private SearchIntegrator searchIntegrator;
   private DatasourceMapper datasourceMapper;
   private HibernateSearchOperations hibernateSearchOperations;
 
@@ -43,15 +42,6 @@ public class HibernateSearchRepositoryFactoryBean<T extends Repository<S, ID>, S
    */
   public HibernateSearchRepositoryFactoryBean(Class<? extends T> repositoryInterface) {
     super(repositoryInterface);
-  }
-
-  /**
-   * Configures the {@link SearchIntegrator} to be used to create Hibernatesearch repositories.
-   *
-   * @param searchIntegrator the search integrator to set
-   */
-  public void setSearchIntegrator(SearchIntegrator searchIntegrator) {
-    this.searchIntegrator = searchIntegrator;
   }
 
   public void setDatasourceMapper(DatasourceMapper datasourceMapper) {
@@ -69,10 +59,9 @@ public class HibernateSearchRepositoryFactoryBean<T extends Repository<S, ID>, S
   @Override
   public void afterPropertiesSet() {
     if (hibernateSearchOperations == null) {
-      Assert.notNull(searchIntegrator, "SearchIntegrator must be configured!");
       Assert.notNull(datasourceMapper, "DatasourceMapper must be configured!");
 
-      hibernateSearchOperations = new HibernateSearchTemplate(searchIntegrator, datasourceMapper);
+      hibernateSearchOperations = new HibernateSearchTemplate(datasourceMapper);
     }
 
     setMappingContext(hibernateSearchOperations.getMappingContext());

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/spi/DatasourceMapper.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/spi/DatasourceMapper.java
@@ -16,9 +16,12 @@
 
 package me.snowdrop.data.hibernatesearch.spi;
 
+import org.hibernate.search.spi.SearchIntegrator;
+
 /**
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public interface DatasourceMapper {
+  SearchIntegrator getSearchIntegrator();
   <T> QueryAdapter createQueryAdapter(Class<T> entityClass);
 }

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/spi/QueryAdapter.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/spi/QueryAdapter.java
@@ -26,7 +26,7 @@ import org.hibernate.search.spi.SearchIntegrator;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public interface QueryAdapter<T> {
-  void applyLuceneQuery(SearchIntegrator searchIntegrator, Query query);
+  void applyLuceneQuery(Query query);
 
   long size();
   List<T> list();

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/TestUtils.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/TestUtils.java
@@ -56,14 +56,15 @@ public class TestUtils {
     return builder.buildSearchIntegrator();
   }
 
-  public static <T> DatasourceMapperForTest<T> createDatasourceMapper(Class<T> entityClass) {
+  public static <T> DatasourceMapperForTest<T> createDatasourceMapper(SearchIntegrator searchIntegrator, Class<T> entityClass) {
     //noinspection unchecked
-    return new DatasourceMapperForTest(entityClass);
+    return new DatasourceMapperForTest(searchIntegrator, entityClass);
   }
 
-  public static void preindexEntities(SearchIntegrator si, DatasourceMapperForTest datasourceMapper, AbstractEntity... entities) {
+  public static void preindexEntities(DatasourceMapperForTest datasourceMapper, AbstractEntity... entities) {
     println("Starting index creation...");
-    Worker worker = si.getWorker();
+    SearchIntegrator searchIntegrator = datasourceMapper.getSearchIntegrator();
+    Worker worker = searchIntegrator.getWorker();
     TransactionContextForTest tc = new TransactionContextForTest();
     boolean needsFlush = false;
     int i = 1;
@@ -87,9 +88,10 @@ public class TestUtils {
     println(" ... created an index of " + (i - 1) + " entities.");
   }
 
-  public static void purgeAll(SearchIntegrator si, DatasourceMapperForTest datasourceMapper, Class<?> entityClass) {
+  public static void purgeAll(DatasourceMapperForTest datasourceMapper, Class<?> entityClass) {
     println("Purging index - " + entityClass.getSimpleName() + " ...");
-    Worker worker = si.getWorker();
+    SearchIntegrator searchIntegrator = datasourceMapper.getSearchIntegrator();
+    Worker worker = searchIntegrator.getWorker();
     TransactionContextForTest tc = new TransactionContextForTest();
     Work work = new Work(entityClass, null, WorkType.PURGE_ALL);
     worker.performWork(work, tc);

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsConfiguration.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsConfiguration.java
@@ -36,8 +36,8 @@ public class OpsConfiguration {
   }
 
   @Bean
-  public DatasourceMapperForTest datasourceMapper() {
-    return TestUtils.createDatasourceMapper(SimpleEntity.class);
+  public DatasourceMapperForTest datasourceMapper(SearchIntegrator searchIntegrator) {
+    return TestUtils.createDatasourceMapper(searchIntegrator, SimpleEntity.class);
   }
 
   @Bean

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsTestsAction.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsTestsAction.java
@@ -31,9 +31,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class OpsTestsAction implements TestsAction {
 
   @Autowired
-  SearchIntegrator searchIntegrator;
-
-  @Autowired
   DatasourceMapperForTest<SimpleEntity> datasourceMapper;
 
   public void setUp() {
@@ -52,10 +49,10 @@ public class OpsTestsAction implements TestsAction {
     entity = new SimpleEntity(6L, "fanny", "Fanny is reading a good book.", 30, false, "Aquaman", "blue");
     entities.add(entity);
 
-    TestUtils.preindexEntities(searchIntegrator, datasourceMapper, entities.toArray(new SimpleEntity[0]));
+    TestUtils.preindexEntities(datasourceMapper, entities.toArray(new SimpleEntity[0]));
   }
 
   public void tearDown() {
-    TestUtils.purgeAll(searchIntegrator, datasourceMapper, SimpleEntity.class);
+    TestUtils.purgeAll(datasourceMapper, SimpleEntity.class);
   }
 }

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/smoke/SmokeTests.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/smoke/SmokeTests.java
@@ -53,16 +53,13 @@ public class SmokeTests {
     }
 
     @Bean
-    public DatasourceMapperForTest datasourceMapper() {
-      return TestUtils.createDatasourceMapper(SmokeEntity.class);
+    public DatasourceMapperForTest datasourceMapper(SearchIntegrator searchIntegrator) {
+      return TestUtils.createDatasourceMapper(searchIntegrator, SmokeEntity.class);
     }
   }
 
   @Autowired
   SmokeRepository repository;
-
-  @Autowired
-  SearchIntegrator searchIntegrator;
 
   @Autowired
   DatasourceMapperForTest datasourceMapper;
@@ -95,12 +92,12 @@ public class SmokeTests {
     entity.setType("baz");
     entities[3] = entity;
 
-    TestUtils.preindexEntities(searchIntegrator, datasourceMapper, entities);
+    TestUtils.preindexEntities(datasourceMapper, entities);
   }
 
   @After
   public void tearDown() {
-    TestUtils.purgeAll(searchIntegrator, datasourceMapper, SmokeEntity.class);
+    TestUtils.purgeAll(datasourceMapper, SmokeEntity.class);
   }
 
   @Test


### PR DESCRIPTION
Because in some cases (in particular, Hibernate Search ORM), the mapper cannot
create a query adapter for just *any* integrator: it only knows how to
create a query adapter for an integrator configured at initialization
time (in the Hibernate Search ORM case, the integrator that was already
set up in the EntityManagerFactory).