### PR TITLE
Test more complex mappings

### DIFF
--- a/config/src/test/resources/META-INF/orm.xml
+++ b/config/src/test/resources/META-INF/orm.xml
@@ -22,4 +22,5 @@
                  version="2.0">
   <entity class="me.snowdrop.data.hibernatesearch.config.smoke.Fruit"/>
   <entity class="me.snowdrop.data.hibernatesearch.ops.SimpleEntity"/>
+  <entity class="me.snowdrop.data.hibernatesearch.ops.ContainedEntity"/>
 </entity-mappings>

--- a/config/src/test/resources/application.properties
+++ b/config/src/test/resources/application.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # Datasource
-spring.datasource.url=jdbc:h2:mem:jpatest;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.url=jdbc:h2:mem:jpatest;DB_CLOSE_ON_EXIT=FALSE?useUnicode=true&characterEncoding=utf-8
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
@@ -23,3 +23,5 @@ spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 spring.jpa.properties.hibernate.search.default.directory_provider=ram
+spring.jpa.properties.hibernate.connection.charSet=UTF-8
+spring.jpa.properties.hibernate.hbm2ddl.import_files_sql_extractor=org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor

--- a/config/src/test/resources/import.sql
+++ b/config/src/test/resources/import.sql
@@ -1,10 +1,12 @@
-insert into fruit (name) values ('Cherry');
-insert into fruit (name) values ('Apple');
-insert into fruit (name) values ('Banana');
+insert into fruit (name) values
+    ('Cherry'),
+    ('Apple'),
+    ('Banana');
 
-insert into simple (name, text, number, buul, hero, color, latitude, longitude) values ('ann', 'Does Ann like good red apples?', -20, true, 'Superman', 'red', 10.0, 10.0)
-insert into simple (name, text, number, buul, hero, color, latitude, longitude) values ('barb', 'Why is Barb dancing twist?', -10, true, 'Spiderman', 'red', 24.0, 32.0)
-insert into simple (name, text, number, buul, hero, color, latitude, longitude) values ('carl', 'Carl is good at running and jumping.', 0, true, 'Flash', 'red', 20.0, 20.0)
-insert into simple (name, text, number, buul, hero, color, latitude, longitude) values ('doug', 'Doug likes to sleeps.', 10, false, 'Batman', 'black', -10.0, -10.0)
-insert into simple (name, text, number, buul, hero, color, latitude, longitude) values ('eva', 'Eva is running in circles.', 20, false, 'Ironman', 'gold', -20.0, 5.0)
-insert into simple (name, text, number, buul, hero, color, latitude, longitude) values ('fanny', 'Fanny is reading a good book.', 30, false, 'Aquaman', 'blue', 5.0, -20.0)
+insert into simple (name, text, number, buul, hero, color, latitude, longitude) values
+    ('ann', 'Does Ann like good red apples?', -20, true, 'Superman', 'red', 10.0, 10.0),
+    ('barb', 'Why is Barb dancing twist?', -10, true, 'Spiderman', 'red', 24.0, 32.0),
+    ('carl', 'Carl is good at running and jumping.', 0, true, 'Flash', 'red', 20.0, 20.0),
+    ('doug', 'Doug likes to sleeps.', 10, false, 'Batman', 'black', -10.0, -10.0),
+    ('eva', 'Eva is running in circles.', 20, false, 'Ironman', 'gold', -20.0, 5.0),
+    ('fanny', 'Fanny is reading a good book.', 30, false, 'Aquaman', 'blue', 5.0, -20.0);

--- a/config/src/test/resources/import.sql
+++ b/config/src/test/resources/import.sql
@@ -10,3 +10,18 @@ insert into simple (name, text, number, buul, hero, color, latitude, longitude) 
     ('doug', 'Doug likes to sleeps.', 10, false, 'Batman', 'black', -10.0, -10.0),
     ('eva', 'Eva is running in circles.', 20, false, 'Ironman', 'gold', -20.0, 5.0),
     ('fanny', 'Fanny is reading a good book.', 30, false, 'Aquaman', 'blue', 5.0, -20.0);
+
+insert into contained (name, number) values
+    ('Frank Dalton', 12),
+    ('Emmett Dalton', 42),
+    ('Oliver Twist', 55);
+
+insert into simple_contained (simple_entity_id, contained_id)
+    (
+    select s.id, c.id
+    from simple s, contained c
+    where
+        s.name = 'ann' and c.name = 'Frank Dalton'
+        or s.name = 'ann' and c.name = 'Emmett Dalton'
+        or s.name = 'eva' and c.name = 'Oliver Twist'
+    );

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/ContainedEntity.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/ContainedEntity.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package me.snowdrop.data.hibernatesearch.ops;
+
+import lombok.*;
+import me.snowdrop.data.hibernatesearch.AbstractEntity;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.bridge.builtin.IntegerBridge;
+import org.springframework.data.annotation.Id;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Table;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+@Entity
+@Table(name = "contained")
+public class ContainedEntity implements AbstractEntity {
+  @Id
+  @DocumentId
+  @javax.persistence.Id
+  @GeneratedValue
+  private Long id;
+  @Field(name = "containedName")
+  private String name;
+  @Field(name = "numberAsText", bridge = @FieldBridge(impl = IntegerBridge.class))
+  private Integer number;
+}

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/MyCustomFieldBridge.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/MyCustomFieldBridge.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package me.snowdrop.data.hibernatesearch.ops;
+
+import org.apache.lucene.document.Document;
+import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
+import org.hibernate.search.bridge.spi.FieldMetadataBuilder;
+import org.hibernate.search.bridge.spi.FieldType;
+
+public class MyCustomFieldBridge implements MetadataProvidingFieldBridge {
+  @Override
+  public void configureFieldMetadata(String name, FieldMetadataBuilder builder) {
+    builder.field(name + ".custom", FieldType.OBJECT);
+    builder.field(name + ".custom.name", FieldType.STRING);
+  }
+
+  @Override
+  public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+    luceneOptions.addFieldToDocument(name + ".custom.name", (String) value, document);
+    luceneOptions.addFieldToDocument(name + ".custom.dynamicName", (String) value, document);
+  }
+}

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsDefaultBase.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsDefaultBase.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import me.snowdrop.data.hibernatesearch.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
@@ -119,6 +120,32 @@ public class OpsDefaultBase extends OpsTestsBase {
   @Test
   public void testNestedProps() {
     //assertSize(repository.findByAddressZipcode(1360), 2);
+  }
+
+  @Test
+  public void testNonDefaultCompositeFieldName() {
+    assertSize(repository.findByIdentity_Name("ann"), 1);
+  }
+
+  @Test
+  public void testBridgeDefinedField() {
+    assertSize(repository.findByBridge_Custom_Name("ann"), 1);
+  }
+
+  @Test
+  public void testBridgeDefinedDynamicField() {
+    assertSize(repository.findByBridge_Custom_DynamicName("ann"), 1);
+  }
+
+  @Test
+  public void testNestedComplexFieldName() {
+    assertSize(repository.findByContainedList_SomePrefixContainedName("Frank"), 1);
+  }
+
+  @Test
+  public void testMisleadingFieldType() {
+    // Should match "42", since the numbers are indexed as strings
+    assertSize(repository.findByContainedList_SomePrefixNumberAsStringBetween(4, 5), 1);
   }
 
   @Test

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsDefaultBase.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsDefaultBase.java
@@ -124,28 +124,28 @@ public class OpsDefaultBase extends OpsTestsBase {
 
   @Test
   public void testNonDefaultCompositeFieldName() {
-    assertSize(repository.findByIdentity_Name("ann"), 1);
+//    assertSize(repository.findByIdentity_Name("ann"), 1);
   }
 
   @Test
   public void testBridgeDefinedField() {
-    assertSize(repository.findByBridge_Custom_Name("ann"), 1);
+//    assertSize(repository.findByBridge_Custom_Name("ann"), 1);
   }
 
   @Test
   public void testBridgeDefinedDynamicField() {
-    assertSize(repository.findByBridge_Custom_DynamicName("ann"), 1);
+//    assertSize(repository.findByBridge_Custom_DynamicName("ann"), 1);
   }
 
   @Test
   public void testNestedComplexFieldName() {
-    assertSize(repository.findByContainedList_SomePrefixContainedName("Frank"), 1);
+//    assertSize(repository.findByContainedList_SomePrefixContainedName("Frank"), 1);
   }
 
   @Test
   public void testMisleadingFieldType() {
     // Should match "42", since the numbers are indexed as strings
-    assertSize(repository.findByContainedList_SomePrefixNumberAsStringBetween(4, 5), 1);
+//    assertSize(repository.findByContainedList_SomePrefixNumberAsStringBetween(4, 5), 1);
   }
 
   @Test

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsRepository.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsRepository.java
@@ -104,13 +104,13 @@ public interface OpsRepository extends HibernateSearchRepository<SimpleEntity, L
 
   List<SimpleEntity> findByColorOrderByNameDesc(String color);
 
-  List<SimpleEntity> findByIdentity_Name(String name);
+//  List<SimpleEntity> findByIdentity_Name(String name);
 
-  List<SimpleEntity> findByBridge_Custom_Name(String name);
+//  List<SimpleEntity> findByBridge_Custom_Name(String name);
 
-  List<SimpleEntity> findByBridge_Custom_DynamicName(String name);
+//  List<SimpleEntity> findByBridge_Custom_DynamicName(String name);
 
-  List<SimpleEntity> findByContainedList_SomePrefixContainedName(String containedName);
+//  List<SimpleEntity> findByContainedList_SomePrefixContainedName(String containedName);
 
-  List<SimpleEntity> findByContainedList_SomePrefixNumberAsStringBetween(int min, int max);
+//  List<SimpleEntity> findByContainedList_SomePrefixNumberAsStringBetween(int min, int max);
 }

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsRepository.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsRepository.java
@@ -103,4 +103,14 @@ public interface OpsRepository extends HibernateSearchRepository<SimpleEntity, L
   List<SimpleEntity> findByColorOrderByNameAsc(String color);
 
   List<SimpleEntity> findByColorOrderByNameDesc(String color);
+
+  List<SimpleEntity> findByIdentity_Name(String name);
+
+  List<SimpleEntity> findByBridge_Custom_Name(String name);
+
+  List<SimpleEntity> findByBridge_Custom_DynamicName(String name);
+
+  List<SimpleEntity> findByContainedList_SomePrefixContainedName(String containedName);
+
+  List<SimpleEntity> findByContainedList_SomePrefixNumberAsStringBetween(int min, int max);
 }

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsTestsActionBase.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsTestsActionBase.java
@@ -17,6 +17,8 @@
 package me.snowdrop.data.hibernatesearch.ops;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import me.snowdrop.data.hibernatesearch.TestsAction;
@@ -28,17 +30,45 @@ public abstract class OpsTestsActionBase implements TestsAction {
   public void setUp() {
     List<SimpleEntity> entities = new ArrayList<>();
 
-    SimpleEntity entity = new SimpleEntity(1L, "ann", "Does Ann like good red apples?", -20, true, "Superman", "red", new Location(10.0, 10.0));
+    ContainedEntity frankDalton = new ContainedEntity( 1L, "Frank Dalton", 41);
+    ContainedEntity emmettDalton = new ContainedEntity( 2L, "Emmett Dalton", 42);
+    ContainedEntity oliverTwist = new ContainedEntity( 3L, "Oliver Twist", 43);
+
+    SimpleEntity entity = new SimpleEntity(
+            1L, "ann", "Does Ann like good red apples?", -20, true,
+            "Superman", "red", new Location(10.0, 10.0),
+            Arrays.asList(frankDalton, emmettDalton)
+    );
     entities.add(entity);
-    entity = new SimpleEntity(2L, "barb", "Why is Barb dancing twist?", -10, true, "Spiderman", "red", new Location(24.0, 32.0));
+    entity = new SimpleEntity(
+            2L, "barb", "Why is Barb dancing twist?", -10, true,
+            "Spiderman", "red", new Location(24.0, 32.0),
+            Collections.emptyList()
+    );
     entities.add(entity);
-    entity = new SimpleEntity(3L, "carl", "Carl is good at running and jumping.", 0, true, "Flash", "red", new Location(20.0, 20.0));
+    entity = new SimpleEntity(
+            3L, "carl", "Carl is good at running and jumping.", 0, true,
+            "Flash", "red", new Location(20.0, 20.0),
+            Collections.emptyList()
+    );
     entities.add(entity);
-    entity = new SimpleEntity(4L, "doug", "Doug likes to sleeps.", 10, false, "Batman", "black", new Location(-10.0, -10.0));
+    entity = new SimpleEntity(
+            4L, "doug", "Doug likes to sleeps.", 10, false,
+            "Batman", "black", new Location(-10.0, -10.0),
+            Collections.emptyList()
+    );
     entities.add(entity);
-    entity = new SimpleEntity(5L, "eva", "Eva is running in circles.", 20, false, "Ironman", "gold", new Location(-20.0, 5.0));
+    entity = new SimpleEntity(
+            5L, "eva", "Eva is running in circles.", 20, false,
+            "Ironman", "gold", new Location(-20.0, 5.0),
+            Arrays.asList(oliverTwist)
+    );
     entities.add(entity);
-    entity = new SimpleEntity(6L, "fanny", "Fanny is reading a good book.", 30, false, "Aquaman", "blue", new Location(5.0, -20.0));
+    entity = new SimpleEntity(
+            6L, "fanny", "Fanny is reading a good book.", 30, false,
+            "Aquaman", "blue", new Location(5.0, -20.0),
+            Collections.emptyList()
+    );
     entities.add(entity);
 
     setUp(entities);

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/SimpleEntity.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/SimpleEntity.java
@@ -16,10 +16,7 @@
 
 package me.snowdrop.data.hibernatesearch.ops;
 
-import javax.persistence.Embedded;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,13 +25,10 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import me.snowdrop.data.hibernatesearch.AbstractEntity;
-import org.hibernate.search.annotations.DocumentId;
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.SortableField;
-import org.hibernate.search.annotations.Spatial;
-import org.hibernate.search.annotations.Store;
+import org.hibernate.search.annotations.*;
 import org.springframework.data.annotation.Id;
+
+import java.util.List;
 
 /**
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
@@ -56,6 +50,8 @@ public class SimpleEntity implements AbstractEntity {
   private Long id;
   @Field(store = Store.NO)
   @SortableField
+  @Field(name = "identity.name")
+  @Field(name = "bridge", bridge = @FieldBridge(impl = MyCustomFieldBridge.class))
   private String name;
   @Field(store = Store.NO)
   private String text;
@@ -72,4 +68,7 @@ public class SimpleEntity implements AbstractEntity {
   @Spatial
   @Embedded
   private Location location;
+  @IndexedEmbedded(prefix = "containedList.somePrefix_")
+  @OneToMany
+  private List<ContainedEntity> contained;
 }


### PR DESCRIPTION
Revert the last commit to enable the tests.

Currently none of the tests pass, and I think it's mostly related to the fact we use Class metadata instead of Hibernate Search metadata to detect field types.

One solution would be to use Hibernate Search metamodel (`org.hibernate.search.spi.SearchIntegrator#getIndexedTypeDescriptor`), but:

1. This metamodel doesn't include bridge-defined fields
2. We wouldn't cover the case of fully dynamic fields (fields added at runtime, but not declared in the schema).

So we may want to remove bootstrap-time metamodel checks altogether... I'd wager some other integrations already do that.