### PR TITLE
Rename QueryHint to TargetField

### DIFF
--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/annotations/TargetField.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/annotations/TargetField.java
@@ -18,16 +18,33 @@ package me.snowdrop.data.hibernatesearch.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * Used when there are multiple fields on the same property.
+ *
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 @Documented
-public @interface QueryHints {
-  QueryHint[] value();
+@Repeatable(TargetFields.class)
+public @interface TargetField {
+
+  /**
+   * Property to map to.
+   *
+   * @return property
+   */
+  String property();
+
+  /**
+   * Mapped field.
+   *
+   * @return mapped field
+   */
+  String field();
 }

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/annotations/TargetFields.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/annotations/TargetFields.java
@@ -18,33 +18,16 @@ package me.snowdrop.data.hibernatesearch.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used when there are multiple fields on the same property.
- *
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 @Documented
-@Repeatable(QueryHints.class)
-public @interface QueryHint {
-
-  /**
-   * Property to map to.
-   *
-   * @return property
-   */
-  String property();
-
-  /**
-   * Mapped field.
-   *
-   * @return mapped field
-   */
-  String field();
+public @interface TargetFields {
+  TargetField[] value();
 }

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/core/query/AbstractQueryAdapter.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/core/query/AbstractQueryAdapter.java
@@ -49,7 +49,7 @@ public abstract class AbstractQueryAdapter<T> implements QueryAdapter<T> {
 
     EntityMetadataContext entityMetadataContext = new EntityMetadataContext(
       getSearchIntegrator().getIndexBinding(getIndexedTypeIdentifier()),
-      query.getQueryHints()
+      query.getTargetFields()
     );
     QueryBuilder queryBuilder = getSearchIntegrator().buildQueryBuilder().forEntity(entityClass).get();
 

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/core/query/BaseQuery.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/core/query/BaseQuery.java
@@ -29,7 +29,7 @@ public class BaseQuery<T> implements Query<T> {
   private Class<T> entityClass;
   private Pageable pageable;
   private Sort sort;
-  private Map<String, String> queryHints;
+  private Map<String, String> targetFields;
 
   public BaseQuery(Class<T> entityClass) {
     this.entityClass = entityClass;
@@ -59,11 +59,11 @@ public class BaseQuery<T> implements Query<T> {
     this.sort = sort;
   }
 
-  public Map<String, String> getQueryHints() {
-    return queryHints;
+  public Map<String, String> getTargetFields() {
+    return targetFields;
   }
 
-  public void setQueryHints(Map<String, String> queryHints) {
-    this.queryHints = queryHints;
+  public void setTargetFields(Map<String, String> targetFields) {
+    this.targetFields = targetFields;
   }
 }

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/core/query/EntityMetadataContext.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/core/query/EntityMetadataContext.java
@@ -29,11 +29,11 @@ import org.hibernate.search.engine.spi.EntityIndexBinding;
  */
 class EntityMetadataContext {
   private final EntityIndexBinding binding;
-  private final Map<String, String> queryHints;
+  private final Map<String, String> targetFields;
 
-  EntityMetadataContext(EntityIndexBinding binding, Map<String, String> queryHints) {
+  EntityMetadataContext(EntityIndexBinding binding, Map<String, String> targetFields) {
     this.binding = binding;
-    this.queryHints = queryHints;
+    this.targetFields = targetFields;
   }
 
   String getFieldName(String property) {
@@ -48,7 +48,7 @@ class EntityMetadataContext {
         case 1:
           return fieldsForProperty.iterator().next().getAbsoluteName();
         default:
-          String field = queryHints.getOrDefault(property, property);
+          String field = targetFields.getOrDefault(property, property);
           for (DocumentFieldMetadata fd : fieldsForProperty) {
             if (field.equals(fd.getAbsoluteName())) {
               return field;
@@ -59,7 +59,7 @@ class EntityMetadataContext {
     }
     // handle nested / inner
     // first check for hint
-    String hint = queryHints.getOrDefault(property, property);
+    String hint = targetFields.getOrDefault(property, property);
     DocumentFieldMetadata field = typeMetadata.getDocumentFieldMetadataFor(hint);
     if (field != null) {
       return field.getAbsoluteName();

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/repository/query/HibernateSearchPartQuery.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/repository/query/HibernateSearchPartQuery.java
@@ -20,8 +20,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import me.snowdrop.data.hibernatesearch.annotations.QueryHint;
-import me.snowdrop.data.hibernatesearch.annotations.QueryHints;
+import me.snowdrop.data.hibernatesearch.annotations.TargetField;
+import me.snowdrop.data.hibernatesearch.annotations.TargetFields;
 import me.snowdrop.data.hibernatesearch.core.HibernateSearchOperations;
 import me.snowdrop.data.hibernatesearch.core.mapping.HibernateSearchPersistentProperty;
 import me.snowdrop.data.hibernatesearch.core.query.BaseQuery;
@@ -61,7 +61,7 @@ public class HibernateSearchPartQuery extends AbstractHibernateSearchRepositoryQ
     Class<?> entityClass = getQueryMethod().getEntityInformation().getJavaType();
     CriteriaQuery<?> query = new HibernateSearchQueryCreator(entityClass, tree, accessor, mappingContext).createQuery();
 
-    query.setQueryHints(getQueryHints());
+    query.setTargetFields(getTargetFields());
 
     query.setMaxResults(tree.getMaxResults());
     query.setDistinct(tree.isDistinct());
@@ -69,14 +69,14 @@ public class HibernateSearchPartQuery extends AbstractHibernateSearchRepositoryQ
     return query;
   }
 
-  private Map<String, String> getQueryHints() {
-    QueryHints queryHints = getQueryMethod().getQueryHints();
-    if (queryHints == null) {
+  private Map<String, String> getTargetFields() {
+    TargetFields targetFields = getQueryMethod().getTargetFields();
+    if (targetFields == null) {
       return Collections.emptyMap();
     }
     Map<String, String> map = new HashMap<>();
-    for (QueryHint queryHint : queryHints.value()) {
-      map.put(queryHint.property(), queryHint.field());
+    for (TargetField targetField : targetFields.value()) {
+      map.put(targetField.property(), targetField.field());
     }
     return Collections.unmodifiableMap(map);
   }

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/repository/query/HibernateSearchQueryMethod.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/repository/query/HibernateSearchQueryMethod.java
@@ -20,8 +20,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 import me.snowdrop.data.hibernatesearch.annotations.Query;
-import me.snowdrop.data.hibernatesearch.annotations.QueryHint;
-import me.snowdrop.data.hibernatesearch.annotations.QueryHints;
+import me.snowdrop.data.hibernatesearch.annotations.TargetField;
+import me.snowdrop.data.hibernatesearch.annotations.TargetFields;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -41,15 +41,15 @@ public class HibernateSearchQueryMethod extends QueryMethod {
     this.queryAnnotation = method.getAnnotation(Query.class);
   }
 
-  public QueryHints getQueryHints() {
-    QueryHints queryHints = method.getAnnotation(QueryHints.class);
-    if (queryHints == null) {
-      QueryHint queryHint = method.getAnnotation(QueryHint.class);
-      if (queryHint != null) {
-        queryHints = new QueryHintsImpl(queryHint);
+  public TargetFields getTargetFields() {
+    TargetFields targetFields = method.getAnnotation(TargetFields.class);
+    if (targetFields == null) {
+      TargetField targetField = method.getAnnotation(TargetField.class);
+      if (targetField != null) {
+        targetFields = new TargetFieldsImpl(targetField);
       }
     }
-    return queryHints;
+    return targetFields;
   }
 
   public boolean hasAnnotatedQuery() {
@@ -60,21 +60,21 @@ public class HibernateSearchQueryMethod extends QueryMethod {
     return (String) AnnotationUtils.getValue(queryAnnotation, "value");
   }
 
-  private static class QueryHintsImpl implements QueryHints {
-    private QueryHint queryHint;
+  private static class TargetFieldsImpl implements TargetFields {
+    private TargetField targetField;
 
-    public QueryHintsImpl(QueryHint queryHint) {
-      this.queryHint = queryHint;
+    public TargetFieldsImpl(TargetField targetField) {
+      this.targetField = targetField;
     }
 
     @Override
-    public QueryHint[] value() {
-      return new QueryHint[]{queryHint};
+    public TargetField[] value() {
+      return new TargetField[]{targetField};
     }
 
     @Override
     public Class<? extends Annotation> annotationType() {
-      return QueryHints.class;
+      return TargetFields.class;
     }
   }
 }

--- a/core/src/main/java/me/snowdrop/data/hibernatesearch/spi/Query.java
+++ b/core/src/main/java/me/snowdrop/data/hibernatesearch/spi/Query.java
@@ -18,8 +18,6 @@ package me.snowdrop.data.hibernatesearch.spi;
 
 import java.util.Map;
 
-import me.snowdrop.data.hibernatesearch.annotations.QueryHint;
-import me.snowdrop.data.hibernatesearch.annotations.QueryHints;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
@@ -33,5 +31,5 @@ public interface Query<T> {
 
   Sort getSort();
 
-  Map<String, String> getQueryHints();
+  Map<String, String> getTargetFields();
 }

--- a/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsRepository.java
+++ b/core/src/test/java/me/snowdrop/data/hibernatesearch/ops/OpsRepository.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import me.snowdrop.data.hibernatesearch.annotations.QueryHint;
+import me.snowdrop.data.hibernatesearch.annotations.TargetField;
 import me.snowdrop.data.hibernatesearch.repository.HibernateSearchRepository;
 import org.springframework.data.domain.Sort;
 
@@ -29,11 +29,11 @@ import org.springframework.data.domain.Sort;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public interface OpsRepository extends HibernateSearchRepository<SimpleEntity, Long> {
-  @QueryHint(property = "dummy1", field = "aaa")
-  @QueryHint(property = "dummy2", field = "bbb")
+  @TargetField(property = "dummy1", field = "aaa")
+  @TargetField(property = "dummy2", field = "bbb")
   long countByColor(String color);
 
-  @QueryHint(property = "name", field = "identity.name")
+  @TargetField(property = "name", field = "identity.name")
   List<SimpleEntity> findByNameNot(String notName);
 
   List<SimpleEntity> findByNumberBetween(int min, int max);
@@ -56,10 +56,10 @@ public interface OpsRepository extends HibernateSearchRepository<SimpleEntity, L
 
   List<SimpleEntity> findByTextNotContaining(String text);
 
-  @QueryHint(property = "name", field = "identity.name")
+  @TargetField(property = "name", field = "identity.name")
   List<SimpleEntity> findByNameIn(Collection<String> names);
 
-  @QueryHint(property = "name", field = "identity.name")
+  @TargetField(property = "name", field = "identity.name")
   List<SimpleEntity> findByNameNotIn(Collection<String> names);
 
   List<SimpleEntity> findByBuulTrue();
@@ -82,7 +82,7 @@ public interface OpsRepository extends HibernateSearchRepository<SimpleEntity, L
 
   List<SimpleEntity> findFirst2ByNumberAfter(int number, Sort sort);
 
-  @QueryHint(property = "name", field = "identity.name")
+  @TargetField(property = "name", field = "identity.name")
   List<SimpleEntity> findByNameNot(String notName, Sort sort);
 
   List<SimpleEntity> findByNumberBetween(int min, int max, Sort sort);
@@ -105,32 +105,32 @@ public interface OpsRepository extends HibernateSearchRepository<SimpleEntity, L
 
   List<SimpleEntity> findByTextNotContaining(String text, Sort sort);
 
-  @QueryHint(property = "name", field = "identity.name")
+  @TargetField(property = "name", field = "identity.name")
   List<SimpleEntity> findByNameIn(Collection<String> names, Sort sort);
 
-  @QueryHint(property = "name", field = "identity.name")
+  @TargetField(property = "name", field = "identity.name")
   List<SimpleEntity> findByNameNotIn(Collection<String> names, Sort sort);
 
   List<SimpleEntity> findByBuulTrue(Sort sort);
 
   List<SimpleEntity> findByBuulFalse(Sort sort);
 
-  @QueryHint(property = "name", field = "identity.name")
+  @TargetField(property = "name", field = "identity.name")
   List<SimpleEntity> findByColorOrderByNameAsc(String color);
 
-  @QueryHint(property = "name", field = "identity.name")
+  @TargetField(property = "name", field = "identity.name")
   List<SimpleEntity> findByColorOrderByNameDesc(String color);
 
-  @QueryHint(property = "name", field = "identity.name")
+  @TargetField(property = "name", field = "identity.name")
   List<SimpleEntity> findByName(String name);
 
 //  List<SimpleEntity> findByBridge_Custom_Name(String name);
 
 //  List<SimpleEntity> findByBridge_Custom_DynamicName(String name);
 
-  @QueryHint(property = "contained.name", field = "containedList.somePrefix_containedName")
+  @TargetField(property = "contained.name", field = "containedList.somePrefix_containedName")
   List<SimpleEntity> findByContainedName(String containedName);
 
-  @QueryHint(property = "contained.number", field = "containedList.somePrefix_numberAsText")
+  @TargetField(property = "contained.number", field = "containedList.somePrefix_numberAsText")
   List<SimpleEntity> findByContainedNumberBetween(int min, int max);
 }


### PR DESCRIPTION
Because if we are to, one day, add actual query hints (such as query
timeout, entity loading hints, ...), we'll be glad that this annotation
name is still available.